### PR TITLE
api.uni.ninja status badge now showing right URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/UniNinja/graphql-api.svg?branch=master)](https://travis-ci.org/UniNinja/graphql-api)
 [![GitHub release](https://img.shields.io/github/release/UniNinja/graphql-api.svg)](https://github.com/UniNinja/graphql-api/releases)
-[![Website](https://img.shields.io/website-up-down-green-red/https/uni.ninja.svg?label=api.uni.ninja)](https://api.uni.ninja)
+[![Website](https://img.shields.io/website-up-down-green-red/https/api.uni.ninja.svg?label=api.uni.ninja)](https://api.uni.ninja)
 [![Website](https://img.shields.io/website-up-down-green-red/https/uni.ninja.svg?label=documentation)](https://uni.ninja)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 


### PR DESCRIPTION
# Pull Request

⚠️ Please read [our contributing guidelines](CONTRIBUTING.md) before submitting this pull request ⚠️

---

The status badge for `api.uni.ninja` is currently showing the status for the wrong website. This PR fixes that.

*I confirm that:*

* [x] I have tested my changes locally on Docker 🐳
* [x] My changes are backwards compatible with the previous version, and if not I am submitting this pull request to the beta branch 🚧

*Please reference any issues that this Pull Request may solve below, providing details on how it solves those issues:*
